### PR TITLE
Спринт 2

### DIFF
--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -8,6 +8,7 @@ import (
 var Options struct {
 	HostAddr string
 	BaseAddr string
+	FilePath string
 }
 
 func Init() {
@@ -18,6 +19,7 @@ func Init() {
 func initFlags() {
 	flag.StringVar(&Options.HostAddr, "a", ":8080", "TCP network address")
 	flag.StringVar(&Options.BaseAddr, "b", "http://localhost:8080", "base address")
+	flag.StringVar(&Options.FilePath, "f", "/tmp/short-url-db.json", "storage path")
 	flag.Parse()
 }
 
@@ -27,5 +29,8 @@ func initEnv() {
 	}
 	if envBaseAddr := os.Getenv("BASE_URL"); envBaseAddr != "" {
 		Options.BaseAddr = envBaseAddr
+	}
+	if envFilePath := os.Getenv("FILE_STORAGE_PATH"); envFilePath != "" {
+		Options.FilePath = envFilePath
 	}
 }

--- a/cmd/shortener/main.go
+++ b/cmd/shortener/main.go
@@ -13,7 +13,11 @@ import (
 
 func main() {
 	config.Init()
-	coder := uricoder.NewCoder(storage.NewStorage(config.Options.FilePath))
+	s, err := storage.NewStorage(config.Options.FilePath)
+	if err != nil {
+		panic(err)
+	}
+	coder := uricoder.NewCoder(s)
 	r := buildRouter(coder)
 
 	if err := http.ListenAndServe(config.Options.HostAddr, r); err != nil {

--- a/cmd/shortener/main.go
+++ b/cmd/shortener/main.go
@@ -25,6 +25,7 @@ func buildRouter(coder *uricoder.Coder) *chi.Mux {
 
 	r := chi.NewRouter()
 	r.Get("/{code}", sugar.Handle(handlers.DecodeHandler(coder)))
+	r.Post("/api/shorten", sugar.Handle(handlers.EncodeJSONHandler(coder)))
 	r.Post("/", sugar.Handle(handlers.EncodeHandler(coder)))
 	r.MethodNotAllowed(sugar.Handle(handlers.NotAllowedHandler()))
 	//r.Use(middleware.Logger)

--- a/cmd/shortener/main.go
+++ b/cmd/shortener/main.go
@@ -12,9 +12,9 @@ import (
 )
 
 func main() {
-	coder := uricoder.NewCoder(storage.NewStorage())
-	r := buildRouter(coder)
 	config.Init()
+	coder := uricoder.NewCoder(storage.NewStorage(config.Options.FilePath))
+	r := buildRouter(coder)
 
 	if err := http.ListenAndServe(config.Options.HostAddr, r); err != nil {
 		panic(err)

--- a/cmd/shortener/main.go
+++ b/cmd/shortener/main.go
@@ -4,6 +4,7 @@ import (
 	"github.com/go-chi/chi"
 	"github.com/yury-kuznetsov/shortener/cmd/config"
 	"github.com/yury-kuznetsov/shortener/internal/app"
+	"github.com/yury-kuznetsov/shortener/internal/logger"
 	"github.com/yury-kuznetsov/shortener/internal/storage"
 	"github.com/yury-kuznetsov/shortener/internal/uricoder"
 	"net/http"
@@ -20,10 +21,13 @@ func main() {
 }
 
 func buildRouter(coder *uricoder.Coder) *chi.Mux {
+	sugar := logger.NewLogger()
+
 	r := chi.NewRouter()
-	r.Get("/{code}", handlers.DecodeHandler(coder))
-	r.Post("/", handlers.EncodeHandler(coder))
-	r.MethodNotAllowed(handlers.NotAllowedHandler())
+	r.Get("/{code}", sugar.Handle(handlers.DecodeHandler(coder)))
+	r.Post("/", sugar.Handle(handlers.EncodeHandler(coder)))
+	r.MethodNotAllowed(sugar.Handle(handlers.NotAllowedHandler()))
+	//r.Use(middleware.Logger)
 
 	return r
 }

--- a/cmd/shortener/main.go
+++ b/cmd/shortener/main.go
@@ -4,6 +4,7 @@ import (
 	"github.com/go-chi/chi"
 	"github.com/yury-kuznetsov/shortener/cmd/config"
 	"github.com/yury-kuznetsov/shortener/internal/app"
+	"github.com/yury-kuznetsov/shortener/internal/gzip"
 	"github.com/yury-kuznetsov/shortener/internal/logger"
 	"github.com/yury-kuznetsov/shortener/internal/storage"
 	"github.com/yury-kuznetsov/shortener/internal/uricoder"
@@ -24,10 +25,10 @@ func buildRouter(coder *uricoder.Coder) *chi.Mux {
 	sugar := logger.NewLogger()
 
 	r := chi.NewRouter()
-	r.Get("/{code}", sugar.Handle(handlers.DecodeHandler(coder)))
-	r.Post("/api/shorten", sugar.Handle(handlers.EncodeJSONHandler(coder)))
-	r.Post("/", sugar.Handle(handlers.EncodeHandler(coder)))
-	r.MethodNotAllowed(sugar.Handle(handlers.NotAllowedHandler()))
+	r.Get("/{code}", gzip.Handle(sugar.Handle(handlers.DecodeHandler(coder))))
+	r.Post("/api/shorten", gzip.Handle(sugar.Handle(handlers.EncodeJSONHandler(coder))))
+	r.Post("/", gzip.Handle(sugar.Handle(handlers.EncodeHandler(coder))))
+	r.MethodNotAllowed(gzip.Handle(sugar.Handle(handlers.NotAllowedHandler())))
 	//r.Use(middleware.Logger)
 
 	return r

--- a/cmd/shortener/main_test.go
+++ b/cmd/shortener/main_test.go
@@ -67,6 +67,18 @@ func TestRequests(t *testing.T) {
 			},
 		},
 		{
+			name: "POST-json-request",
+			request: request{
+				method: http.MethodPost,
+				target: "/api/shorten",
+				body:   "{\"url\": \"https://ya.ru\"}",
+			},
+			response: response{
+				status: http.StatusCreated,
+				error:  nil,
+			},
+		},
+		{
 			name: "PUT-request",
 			request: request{
 				method: http.MethodPut,

--- a/cmd/shortener/main_test.go
+++ b/cmd/shortener/main_test.go
@@ -31,7 +31,10 @@ type testCase struct {
 }
 
 func TestRequests(t *testing.T) {
-	coder := uricoder.NewCoder(storage.NewStorage(""))
+	s, err := storage.NewStorage("")
+	require.NoError(t, err)
+
+	coder := uricoder.NewCoder(s)
 
 	ts := httptest.NewServer(buildRouter(coder))
 	defer ts.Close()
@@ -128,7 +131,10 @@ func testRequest(t *testing.T, ts *httptest.Server, test testCase) {
 }
 
 func TestGzipCompression(t *testing.T) {
-	coder := uricoder.NewCoder(storage.NewStorage(""))
+	s, err := storage.NewStorage("")
+	require.NoError(t, err)
+
+	coder := uricoder.NewCoder(s)
 	ts := httptest.NewServer(buildRouter(coder))
 	defer ts.Close()
 

--- a/cmd/shortener/main_test.go
+++ b/cmd/shortener/main_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"bytes"
+	"compress/gzip"
 	"errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -107,6 +109,10 @@ func testRequest(t *testing.T, ts *httptest.Server, test testCase) {
 	)
 	require.NoError(t, err)
 
+	// махинизм сжатие проверим отдельно
+	req.Header.Set("Accept-Encoding", "")
+	req.Header.Set("Content-Encoding", "")
+
 	resp, err := ts.Client().Do(req)
 	require.NoError(t, err)
 	defer resp.Body.Close()
@@ -119,4 +125,53 @@ func testRequest(t *testing.T, ts *httptest.Server, test testCase) {
 	if test.response.error != nil {
 		assert.Equal(t, test.response.error.Error(), string(respBody))
 	}
+}
+
+func TestGzipCompression(t *testing.T) {
+	coder := uricoder.NewCoder(storage.NewStorage())
+	ts := httptest.NewServer(buildRouter(coder))
+	defer ts.Close()
+
+	t.Run("sends_gzip", func(t *testing.T) {
+		buf := bytes.NewBuffer(nil)
+		zb := gzip.NewWriter(buf)
+		_, err := zb.Write([]byte("https://google.com"))
+		require.NoError(t, err)
+		err = zb.Close()
+		require.NoError(t, err)
+
+		r := httptest.NewRequest("POST", ts.URL+"/", buf)
+		r.RequestURI = ""
+		r.Header.Set("Content-Encoding", "gzip")
+
+		resp, err := http.DefaultClient.Do(r)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusCreated, resp.StatusCode)
+
+		defer resp.Body.Close()
+
+		_, err = io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusCreated, resp.StatusCode)
+	})
+
+	t.Run("accepts_gzip", func(t *testing.T) {
+		buf := bytes.NewBufferString("https://ya.ru")
+		r := httptest.NewRequest("POST", ts.URL+"/", buf)
+		r.RequestURI = ""
+		r.Header.Set("Accept-Encoding", "gzip")
+
+		resp, err := http.DefaultClient.Do(r)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusCreated, resp.StatusCode)
+
+		defer resp.Body.Close()
+
+		zr, err := gzip.NewReader(resp.Body)
+		require.NoError(t, err)
+
+		_, err = io.ReadAll(zr)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusCreated, resp.StatusCode)
+	})
 }

--- a/cmd/shortener/main_test.go
+++ b/cmd/shortener/main_test.go
@@ -31,7 +31,7 @@ type testCase struct {
 }
 
 func TestRequests(t *testing.T) {
-	coder := uricoder.NewCoder(storage.NewStorage())
+	coder := uricoder.NewCoder(storage.NewStorage(""))
 
 	ts := httptest.NewServer(buildRouter(coder))
 	defer ts.Close()
@@ -128,7 +128,7 @@ func testRequest(t *testing.T, ts *httptest.Server, test testCase) {
 }
 
 func TestGzipCompression(t *testing.T) {
-	coder := uricoder.NewCoder(storage.NewStorage())
+	coder := uricoder.NewCoder(storage.NewStorage(""))
 	ts := httptest.NewServer(buildRouter(coder))
 	defer ts.Close()
 

--- a/go.mod
+++ b/go.mod
@@ -9,5 +9,7 @@ require (
 	github.com/go-chi/chi v1.5.5 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/stretchr/objx v0.5.0 // indirect
+	go.uber.org/multierr v1.11.0 // indirect
+	go.uber.org/zap v1.26.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -13,6 +13,10 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
+go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=
+go.uber.org/multierr v1.11.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
+go.uber.org/zap v1.26.0 h1:sI7k6L95XOKS281NhVKOFCUNIvv9e0w4BF8N3u+tCRo=
+go.uber.org/zap v1.26.0/go.mod h1:dtElttAiwGvoJ/vj4IwHBS/gXsEu/pZ50mUIRWuG0so=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/internal/app/handlers_test.go
+++ b/internal/app/handlers_test.go
@@ -12,13 +12,12 @@ import (
 )
 
 func TestDecodeHandler(t *testing.T) {
-	mapStorage := storage.NewStorage("")
+	mapStorage, err := storage.NewStorage("")
+	require.NoError(t, err)
 	coder := uricoder.NewCoder(mapStorage)
 
-	codes := [2]string{
-		mapStorage.Set("https://google.com"),
-		mapStorage.Set(""),
-	}
+	code1, _ := mapStorage.Set("https://google.com")
+	code2, _ := mapStorage.Set("")
 
 	tests := []struct {
 		name   string
@@ -27,12 +26,12 @@ func TestDecodeHandler(t *testing.T) {
 	}{
 		{
 			name:   "google",
-			code:   codes[0],
+			code:   code1,
 			status: http.StatusTemporaryRedirect,
 		},
 		{
 			name:   "bad request",
-			code:   codes[1],
+			code:   code2,
 			status: http.StatusBadRequest,
 		},
 	}
@@ -50,7 +49,10 @@ func TestDecodeHandler(t *testing.T) {
 }
 
 func TestEncodeHandler(t *testing.T) {
-	coder := uricoder.NewCoder(storage.NewStorage(""))
+	mapStorage, err := storage.NewStorage("")
+	require.NoError(t, err)
+
+	coder := uricoder.NewCoder(mapStorage)
 	tests := []struct {
 		name   string
 		uri    string

--- a/internal/app/handlers_test.go
+++ b/internal/app/handlers_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestDecodeHandler(t *testing.T) {
-	mapStorage := storage.NewStorage()
+	mapStorage := storage.NewStorage("")
 	coder := uricoder.NewCoder(mapStorage)
 
 	codes := [2]string{
@@ -50,7 +50,7 @@ func TestDecodeHandler(t *testing.T) {
 }
 
 func TestEncodeHandler(t *testing.T) {
-	coder := uricoder.NewCoder(storage.NewStorage())
+	coder := uricoder.NewCoder(storage.NewStorage(""))
 	tests := []struct {
 		name   string
 		uri    string

--- a/internal/gzip/gzip.go
+++ b/internal/gzip/gzip.go
@@ -1,0 +1,101 @@
+package gzip
+
+import (
+	"compress/gzip"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+)
+
+type compressWriter struct {
+	w  http.ResponseWriter
+	zw *gzip.Writer
+}
+
+func newCompressWriter(w http.ResponseWriter) *compressWriter {
+	return &compressWriter{
+		w:  w,
+		zw: gzip.NewWriter(w),
+	}
+}
+
+func (c *compressWriter) Header() http.Header {
+	return c.w.Header()
+}
+
+func (c *compressWriter) Write(p []byte) (int, error) {
+	return c.zw.Write(p)
+}
+
+func (c *compressWriter) WriteHeader(statusCode int) {
+	if statusCode < 300 {
+		c.w.Header().Set("Content-Encoding", "gzip")
+	}
+	c.w.WriteHeader(statusCode)
+}
+
+func (c *compressWriter) Close() error {
+	return c.zw.Close()
+}
+
+type compressReader struct {
+	r  io.ReadCloser
+	zr *gzip.Reader
+}
+
+func newCompressReader(r io.ReadCloser) (*compressReader, error) {
+	zr, err := gzip.NewReader(r)
+	if err != nil {
+		return nil, err
+	}
+
+	return &compressReader{
+		r:  r,
+		zr: zr,
+	}, nil
+}
+
+func (c compressReader) Read(p []byte) (n int, err error) {
+	return c.zr.Read(p)
+}
+
+func (c *compressReader) Close() error {
+	if err := c.r.Close(); err != nil {
+		return err
+	}
+	return c.zr.Close()
+}
+
+func Handle(handler http.HandlerFunc) http.HandlerFunc {
+	handlerFunc := func(res http.ResponseWriter, req *http.Request) {
+		ow := res
+
+		// проверяем, что клиент умеет получать сжатые данные
+		acceptEncoding := req.Header.Get("Accept-Encoding")
+		supportsGzip := strings.Contains(acceptEncoding, "gzip")
+		if supportsGzip {
+			cw := newCompressWriter(res)
+			ow = cw
+			defer cw.Close()
+		}
+
+		// проверяем, что клиент отправил сжатые данные
+		contentEncoding := req.Header.Get("Content-Encoding")
+		sendsGzip := strings.Contains(contentEncoding, "gzip")
+		if sendsGzip {
+			cr, err := newCompressReader(req.Body)
+			if err != nil {
+				fmt.Println(err.Error())
+				res.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+			req.Body = cr
+			defer cr.Close()
+		}
+
+		handler(ow, req)
+	}
+
+	return handlerFunc
+}

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -1,0 +1,51 @@
+package logger
+
+import (
+	"go.uber.org/zap"
+	"net/http"
+	"time"
+)
+
+type Logger struct {
+	sugar zap.SugaredLogger
+}
+
+func NewLogger() *Logger {
+	loggerZap, err := zap.NewDevelopment()
+	if err != nil {
+		panic("cannot initialize logger")
+	}
+	defer loggerZap.Sync()
+
+	logger := Logger{sugar: *loggerZap.Sugar()}
+
+	return &logger
+}
+
+func (l *Logger) Handle(handler http.HandlerFunc) http.HandlerFunc {
+	handlerFunc := func(res http.ResponseWriter, req *http.Request) {
+		start := time.Now()
+		requestURI := req.RequestURI
+		responseData := &responseData{
+			status: 0,
+			size:   0,
+		}
+		lw := loggingResponseWriter{
+			ResponseWriter: res,
+			responseData:   responseData,
+		}
+
+		handler(&lw, req)
+
+		duration := time.Since(start)
+		l.sugar.Infoln(
+			"uri", requestURI,
+			"method", req.Method,
+			"status", responseData.status,
+			"duration", duration,
+			"size", responseData.size,
+		)
+	}
+
+	return handlerFunc
+}

--- a/internal/logger/writer.go
+++ b/internal/logger/writer.go
@@ -1,0 +1,24 @@
+package logger
+
+import "net/http"
+
+type responseData struct {
+	status int
+	size   int
+}
+
+type loggingResponseWriter struct {
+	http.ResponseWriter
+	responseData *responseData
+}
+
+func (r *loggingResponseWriter) Write(b []byte) (int, error) {
+	size, err := r.ResponseWriter.Write(b)
+	r.responseData.size += size
+	return size, err
+}
+
+func (r *loggingResponseWriter) WriteHeader(statusCode int) {
+	r.ResponseWriter.WriteHeader(statusCode)
+	r.responseData.status = statusCode
+}

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -1,0 +1,9 @@
+package models
+
+type EncodeRequest struct {
+	URL string `json:"url"`
+}
+
+type EncodeResponse struct {
+	Result string `json:"result"`
+}

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -15,23 +15,22 @@ func (s *Storage) Get(code string) string {
 	return (*s)[code]
 }
 
-func (s *Storage) Set(value string) string {
+func (s *Storage) Set(value string) (string, error) {
 	key := generateKey()
 	(*s)[key] = value
-
 	if err := saveToFile(s); err != nil {
-		panic(err)
+		return "", err
 	}
-	return key
+	return key, nil
 }
 
-func NewStorage(fName string) *Storage {
+func NewStorage(fName string) (*Storage, error) {
 	s := make(Storage)
 	filename = fName
 	if err := loadFromFile(&s); err != nil {
-		panic(err)
+		return &s, err
 	}
-	return &s
+	return &s, nil
 }
 
 func generateKey() string {

--- a/internal/storage/storage_test.go
+++ b/internal/storage/storage_test.go
@@ -6,9 +6,11 @@ import (
 )
 
 func TestStorage(t *testing.T) {
-	storage := NewStorage("")
+	storage, err := NewStorage("")
+	assert.NoError(t, err)
 
-	key := storage.Set("https://site.com")
+	key, err := storage.Set("https://site.com")
+	assert.NoError(t, err)
 	assert.NotEmpty(t, key)
 
 	uri := storage.Get(key)

--- a/internal/storage/storage_test.go
+++ b/internal/storage/storage_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestStorage(t *testing.T) {
-	storage := NewStorage()
+	storage := NewStorage("")
 
 	key := storage.Set("https://site.com")
 	assert.NotEmpty(t, key)

--- a/internal/uricoder/uricoder.go
+++ b/internal/uricoder/uricoder.go
@@ -27,5 +27,5 @@ func (coder *Coder) ToCode(uri string) (string, error) {
 	if err != nil {
 		return "", errors.New("incorrect URI")
 	}
-	return coder.storage.Set(uri), nil
+	return coder.storage.Set(uri)
 }

--- a/internal/uricoder/uricoder_test.go
+++ b/internal/uricoder/uricoder_test.go
@@ -3,18 +3,20 @@ package uricoder
 import (
 	"errors"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/yury-kuznetsov/shortener/internal/storage"
 	"testing"
 )
 
 func TestToURI(t *testing.T) {
-	coder := NewCoder(storage.NewStorage(""))
+	s, err := storage.NewStorage("")
+	require.NoError(t, err)
 
-	codes := [3]string{
-		coder.storage.Set("https://google.com"),
-		coder.storage.Set("https://ya.ru"),
-		coder.storage.Set(""),
-	}
+	coder := NewCoder(s)
+
+	code1, _ := s.Set("https://google.com")
+	code2, _ := s.Set("https://ya.ru")
+	code3, _ := s.Set("")
 
 	tests := []struct {
 		name string
@@ -24,19 +26,19 @@ func TestToURI(t *testing.T) {
 	}{
 		{
 			name: "google",
-			code: codes[0],
+			code: code1,
 			uri:  "https://google.com",
 			err:  nil,
 		},
 		{
 			name: "yandex",
-			code: codes[1],
+			code: code2,
 			uri:  "https://ya.ru",
 			err:  nil,
 		},
 		{
 			name: "not found",
-			code: codes[2],
+			code: code3,
 			uri:  "",
 			err:  errors.New("URI not found"),
 		},
@@ -52,7 +54,10 @@ func TestToURI(t *testing.T) {
 }
 
 func TestToCode(t *testing.T) {
-	coder := NewCoder(storage.NewStorage(""))
+	s, err := storage.NewStorage("")
+	require.NoError(t, err)
+
+	coder := NewCoder(s)
 
 	tests := []struct {
 		name string

--- a/internal/uricoder/uricoder_test.go
+++ b/internal/uricoder/uricoder_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestToURI(t *testing.T) {
-	coder := NewCoder(storage.NewStorage())
+	coder := NewCoder(storage.NewStorage(""))
 
 	codes := [3]string{
 		coder.storage.Set("https://google.com"),
@@ -52,7 +52,7 @@ func TestToURI(t *testing.T) {
 }
 
 func TestToCode(t *testing.T) {
-	coder := NewCoder(storage.NewStorage())
+	coder := NewCoder(storage.NewStorage(""))
 
 	tests := []struct {
 		name string


### PR DESCRIPTION
# Итоговый PR второго спринта

## Выполненная работа
### 6 инкремент: логирование запроса и ответа
Сейчас подключение `sugar` происходит так:
```go
r.Get("/{code}", sugar.Handle(handlers.DecodeHandler(coder)))
r.Post("/api/shorten", sugar.Handle(handlers.EncodeJSONHandler(coder)))
r.Post("/", sugar.Handle(handlers.EncodeHandler(coder)))
r.MethodNotAllowed(sugar.Handle(handlers.NotAllowedHandler()))
```
В перспективе нужно перенести его в `SugarMiddleware`:
```go
r.Get("/{code}", handlers.DecodeHandler(coder))
r.Post("/api/shorten", handlers.EncodeJSONHandler(coder))
r.Post("/", handlers.EncodeHandler(coder))
r.MethodNotAllowed(handlers.NotAllowedHandler())
r.Use(logger.SugarMiddleware)
```
### 7 инкремент: добавление эндпоинта "/api/shorten"
Тут без комментариев: сложностей не возникло. 

### 8 инкремент: поддержка сжатия gzip
Тут также, как и в случае с логгером, надо бы вынести его в `GzipMiddleware`:
```go
r.Get("/{code}", handlers.DecodeHandler(coder))
r.Post("/api/shorten", handlers.EncodeJSONHandler(coder))
r.Post("/", handlers.EncodeHandler(coder))
r.MethodNotAllowed(handlers.NotAllowedHandler())
r.Use(logger.Middleware, gzip.Middleware)
```
Осталось загадкой, почему он не видится при переносе его в main-пакет (вызов уже через `Handle` без указания пакета; пробовал и другие имена - результат такой же). 
### 9 инкремент: сохранение данных на диск
Возможно, следует вынести эту логику в отдельный `filestorage` (а `storage` переименовать в `mapstorage`). Идея здравая, но осталась за бортом из-за цейтнота. 

Про сбрасывание на диск. Сейчас это работает при каждом POST-вызове. Кажется верным делать это по сигналу ОС из [замечания](https://github.com/yury-kuznetsov/shortener/pull/6#discussion_r1361666063) прошлого PR-a на триггер остановки сервера. Но так как эта тема в стороне от программы обучения, то я в смятении: использовать или все-таки пока не отклоняться от курса. 

